### PR TITLE
Fix - cannot break the wakeEvents$ stream with foreign errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kombo",
-  "version": "0.85.2",
+  "version": "0.85.3",
   "author": {
     "name": "Tomas Machalek"
   },

--- a/src/kombo/model/stateful.ts
+++ b/src/kombo/model/stateful.ts
@@ -230,16 +230,17 @@ export abstract class StatefulModel<T, U={}> implements IEventEmitter, IModel<T>
         if (typeof this.wakeFn === 'function' && this.syncData !== null) {
             try {
                 const ans = this.wakeFn(action, this.syncData);
-                if (action.error) {
+                if (ans === null) { // model is going to wake-up
                     this.wakeFn = null;
-                    this.wakeEvents$.error(action.error);
+                    if (action.error) {
+                        this.wakeEvents$.error(action.error);
 
-                } else if (ans === null) {
-                    this.wakeFn = null;
-                    this.wakeEvents$.next(action);
-                    this.wakeEvents$.complete();
+                    } else {
+                        this.wakeEvents$.next(action);
+                        this.wakeEvents$.complete();
+                    }
 
-                } else if (ans !== this.syncData) {
+                } else if (ans !== this.syncData) { // model keeps sleeping but passes the action
                     this.wakeEvents$.next(action);
                     this.syncData = ans;
                 }

--- a/src/kombo/model/stateless.ts
+++ b/src/kombo/model/stateless.ts
@@ -320,16 +320,17 @@ export abstract class StatelessModel<T extends object, U={}> implements IStatele
         if (typeof this.wakeFn === 'function' && this.syncData !== null) {
             try {
                 const ans = this.wakeFn(action, this.syncData);
-                if (action.error) {
+                if (ans === null) { // model is going to wake-up
                     this.wakeFn = null;
-                    this.wakeEvents$.error(action.error);
+                    if (action.error) {
+                        this.wakeEvents$.error(action.error);
 
-                } else if (ans === null) {
-                    this.wakeFn = null;
-                    this.wakeEvents$.next(action);
-                    this.wakeEvents$.complete();
+                    } else {
+                        this.wakeEvents$.next(action);
+                        this.wakeEvents$.complete();
+                    }
 
-                } else if (ans !== this.syncData) {
+                } else if (ans !== this.syncData) { // model keeps sleeping but passes the action
                     this.wakeEvents$.next(action);
                     this.syncData = ans;
                 }


### PR DESCRIPTION
I.e. many possible errors goes through as part of action a
suspended model is not interested in. Now, only when waking up,
the stream may end up with an error state.